### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Build Status](http://allthebadges.io/jwaldrip/flatrack/travis.png)](http://allthebadges.io/jwaldrip/flatrack/travis)
 [![Coverage Status](https://coveralls.io/repos/jwaldrip/flatrack/badge.png?branch=master)](https://coveralls.io/r/jwaldrip/flatrack?branch=master)
 [![Code Climate](http://allthebadges.io/jwaldrip/flatrack/code_climate.png)](http://allthebadges.io/jwaldrip/flatrack/code_climate)
+[![Inline docs](http://inch-pages.github.io/github/jwaldrip/flatrack.png)](http://inch-pages.github.io/github/jwaldrip/flatrack)
 
 ## About
 A simple rack web layer for delivering rendered static files.


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/jwaldrip/flatrack.png)

Your status page for this project is http://inch-pages.github.io/github/jwaldrip/flatrack

Thanks for giving this a shot!
